### PR TITLE
WIP: Barcode scans open action modals automatically

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     -   id: check-yaml
     -   id: mixed-line-ending
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.3
+    rev: v0.11.13
     hooks:
     - id: ruff-format
       args: [--preview]
@@ -28,7 +28,7 @@ repos:
         --preview
       ]
 -   repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.5.1
+    rev: 0.7.12
     hooks:
       - id: pip-compile
         name: pip-compile requirements-dev.in
@@ -51,11 +51,11 @@ repos:
         args: [contrib/container/requirements.in, -o, contrib/container/requirements.txt, --python-version=3.11, --no-strip-extras, --generate-hashes]
         files: contrib/container/requirements\.(in|txt)$
 -   repo: https://github.com/Riverside-Healthcare/djLint
-    rev: v1.36.1
+    rev: v1.36.4
     hooks:
       - id: djlint-django
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.3.0
+  rev: v2.4.1
   hooks:
   - id: codespell
     additional_dependencies:
@@ -70,13 +70,13 @@ repos:
           src/frontend/vite.config.ts |
       )$
 -   repo: https://github.com/biomejs/pre-commit
-    rev: "v0.5.0"
+    rev: "v2.0.0-beta.5"
     hooks:
     -   id: biome-check
         additional_dependencies: ["@biomejs/biome@1.9.4"]
         files: ^src/frontend/.*\.(js|ts|tsx)$
 -   repo: https://github.com/gitleaks/gitleaks
-    rev: v8.21.2
+    rev: v8.27.0
     hooks:
     -   id: gitleaks
 #-   repo: https://github.com/jumanjihouse/pre-commit-hooks

--- a/src/frontend/src/pages/stock/StockDetail.tsx
+++ b/src/frontend/src/pages/stock/StockDetail.tsx
@@ -11,8 +11,8 @@ import {
   IconSitemap
 } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
-import { type ReactNode, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { api } from '../../App';
 import AdminButton from '../../components/buttons/AdminButton';
@@ -77,6 +77,8 @@ import { StockTrackingTable } from '../../tables/stock/StockTrackingTable';
 
 export default function StockDetail() {
   const { id } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const onOpenAction = searchParams.get('open')?.toLowerCase();
 
   const user = useUserState();
 
@@ -658,24 +660,122 @@ export default function StockDetail() {
     parts: stockitem.part_detail ? [stockitem.part_detail] : []
   });
 
+  // Can this stock item be transferred to a different location?
+  const canTransfer =
+    user.hasChangeRole(UserRoles.stock) &&
+    !stockitem.sales_order &&
+    !stockitem.belongs_to &&
+    !stockitem.customer &&
+    !stockitem.consumed_by;
+
+  const isBuilding = stockitem.is_building;
+
+  const serial = stockitem.serial;
+  const serialized =
+    serial != null &&
+    serial != undefined &&
+    serial != '' &&
+    stockitem.quantity == 1;
+
+  const openActions = [
+    {
+      name: t`Count`,
+      tooltip: t`Count stock`,
+      hidden: serialized || !canTransfer || isBuilding,
+      icon: <InvenTreeIcon icon='stocktake' iconProps={{ color: 'blue' }} />,
+      onClick: () => {
+        stockitem.pk && countStockItem.open();
+      }
+    },
+    {
+      name: t`Add`,
+      tooltip: t`Add Stock`,
+      hidden: serialized || !canTransfer || isBuilding,
+      icon: <InvenTreeIcon icon='add' iconProps={{ color: 'green' }} />,
+      onClick: () => {
+        stockitem.pk && addStockItem.open();
+      }
+    },
+    {
+      name: t`Remove`,
+      tooltip: t`Remove Stock`,
+      hidden:
+        serialized || !canTransfer || isBuilding || stockitem.quantity <= 0,
+      icon: <InvenTreeIcon icon='remove' iconProps={{ color: 'red' }} />,
+      onClick: () => {
+        stockitem.pk && removeStockItem.open();
+      }
+    },
+    {
+      name: t`Transfer`,
+      tooltip: t`Transfer Stock`,
+      hidden: !canTransfer,
+      icon: <InvenTreeIcon icon='transfer' iconProps={{ color: 'blue' }} />,
+      onClick: () => {
+        stockitem.pk && transferStockItem.open();
+      }
+    },
+    {
+      name: t`Serialize`,
+      tooltip: t`Serialize stock`,
+      hidden:
+        isBuilding ||
+        serialized ||
+        stockitem?.quantity < 1 ||
+        stockitem?.part_detail?.trackable != true,
+      icon: <InvenTreeIcon icon='serial' iconProps={{ color: 'blue' }} />,
+      onClick: () => {
+        serializeStockItem.open();
+      }
+    },
+    {
+      name: t`Order`,
+      tooltip: t`Order Stock`,
+      hidden:
+        !user.hasAddRole(UserRoles.purchase_order) ||
+        !stockitem.part_detail?.active ||
+        !stockitem.part_detail?.purchaseable,
+      icon: <IconShoppingCart color='blue' />,
+      onClick: () => {
+        orderPartsWizard.openWizard();
+      }
+    },
+    {
+      name: t`Return`,
+      tooltip: t`Return from customer`,
+      hidden: !stockitem.customer,
+      icon: (
+        <InvenTreeIcon icon='return_orders' iconProps={{ color: 'blue' }} />
+      ),
+      onClick: () => {
+        stockitem.pk && returnStockItem.open();
+      }
+    },
+    {
+      name: t`Assign to Customer`,
+      tooltip: t`Assign to a customer`,
+      hidden: !!stockitem.customer,
+      icon: <InvenTreeIcon icon='customer' iconProps={{ color: 'blue' }} />,
+      onClick: () => {
+        stockitem.pk && assignToCustomer.open();
+      }
+    }
+  ];
+
+  useEffect(() => {
+    if (stockitem.pk) {
+      console.log('Stock PK:', stockitem.pk, '- Open:', onOpenAction);
+      openActions.forEach((action) => {
+        console.log('Action:', action.name);
+        const actionName = action.name.split(' ')[0].toLowerCase();
+        if (!action.hidden && actionName === onOpenAction) {
+          action.onClick();
+        }
+      });
+    }
+  }, [stockitem.pk, onOpenAction]);
+
   const stockActions = useMemo(() => {
-    // Can this stock item be transferred to a different location?
-    const canTransfer =
-      user.hasChangeRole(UserRoles.stock) &&
-      !stockitem.sales_order &&
-      !stockitem.belongs_to &&
-      !stockitem.customer &&
-      !stockitem.consumed_by;
-
-    const isBuilding = stockitem.is_building;
-
-    const serial = stockitem.serial;
-    const serialized =
-      serial != null &&
-      serial != undefined &&
-      serial != '' &&
-      stockitem.quantity == 1;
-
     return [
       <AdminButton model={ModelType.stockitem} id={stockitem.pk} />,
       <LocateItemButton stockId={stockitem.pk} />,
@@ -694,102 +794,7 @@ export default function StockDetail() {
       <ActionDropdown
         tooltip={t`Stock Operations`}
         icon={<IconPackages />}
-        actions={[
-          {
-            name: t`Count`,
-            tooltip: t`Count stock`,
-            hidden: serialized || !canTransfer || isBuilding,
-            icon: (
-              <InvenTreeIcon icon='stocktake' iconProps={{ color: 'blue' }} />
-            ),
-            onClick: () => {
-              stockitem.pk && countStockItem.open();
-            }
-          },
-          {
-            name: t`Add`,
-            tooltip: t`Add Stock`,
-            hidden: serialized || !canTransfer || isBuilding,
-            icon: <InvenTreeIcon icon='add' iconProps={{ color: 'green' }} />,
-            onClick: () => {
-              stockitem.pk && addStockItem.open();
-            }
-          },
-          {
-            name: t`Remove`,
-            tooltip: t`Remove Stock`,
-            hidden:
-              serialized ||
-              !canTransfer ||
-              isBuilding ||
-              stockitem.quantity <= 0,
-            icon: <InvenTreeIcon icon='remove' iconProps={{ color: 'red' }} />,
-            onClick: () => {
-              stockitem.pk && removeStockItem.open();
-            }
-          },
-          {
-            name: t`Transfer`,
-            tooltip: t`Transfer Stock`,
-            hidden: !canTransfer,
-            icon: (
-              <InvenTreeIcon icon='transfer' iconProps={{ color: 'blue' }} />
-            ),
-            onClick: () => {
-              stockitem.pk && transferStockItem.open();
-            }
-          },
-          {
-            name: t`Serialize`,
-            tooltip: t`Serialize stock`,
-            hidden:
-              isBuilding ||
-              serialized ||
-              stockitem?.quantity < 1 ||
-              stockitem?.part_detail?.trackable != true,
-            icon: <InvenTreeIcon icon='serial' iconProps={{ color: 'blue' }} />,
-            onClick: () => {
-              serializeStockItem.open();
-            }
-          },
-          {
-            name: t`Order`,
-            tooltip: t`Order Stock`,
-            hidden:
-              !user.hasAddRole(UserRoles.purchase_order) ||
-              !stockitem.part_detail?.active ||
-              !stockitem.part_detail?.purchaseable,
-            icon: <IconShoppingCart color='blue' />,
-            onClick: () => {
-              orderPartsWizard.openWizard();
-            }
-          },
-          {
-            name: t`Return`,
-            tooltip: t`Return from customer`,
-            hidden: !stockitem.customer,
-            icon: (
-              <InvenTreeIcon
-                icon='return_orders'
-                iconProps={{ color: 'blue' }}
-              />
-            ),
-            onClick: () => {
-              stockitem.pk && returnStockItem.open();
-            }
-          },
-          {
-            name: t`Assign to Customer`,
-            tooltip: t`Assign to a customer`,
-            hidden: !!stockitem.customer,
-            icon: (
-              <InvenTreeIcon icon='customer' iconProps={{ color: 'blue' }} />
-            ),
-            onClick: () => {
-              stockitem.pk && assignToCustomer.open();
-            }
-          }
-        ]}
+        actions={openActions}
       />,
       <OptionsActionDropdown
         tooltip={t`Stock Item Actions`}


### PR DESCRIPTION
Allow opening specified action modals automatically when the page loads. This saves navigation and clicks and can take you to the correct modal with a single barcode scan. 

This PR enables passing action modal names as a URL search/query parameter, tentatively named "?open=". Certain pages, such as the stock item page, can check that field when they load and open the corresponding modal automatically. The "action verb" to pass in the URL is the first word of the action name in the dropdown. It will not show modals if they are supposed to be hidden.


